### PR TITLE
Fixed django 1.8 allow_migrate router signature, documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,12 +160,12 @@ created ``Client`` inside an app named ``customers``, your
 
     TENANT_MODEL = "customers.Client" # app.Model
 
-Now run ``sync_schemas``, this will sync your apps to the ``public``
+Now run ``migrate_schemas``, this will sync your apps to the ``public``
 schema.
 
 ::
 
-    python manage.py sync_schemas --shared
+    python manage.py migrate_schemas --shared
 
 Create your tenants just like a normal django model. Calling ``save``
 will automatically create and sync the schema.

--- a/django_tenants/management/commands/syncdb.py
+++ b/django_tenants/management/commands/syncdb.py
@@ -12,7 +12,7 @@ class Command(syncdb.Command):
         if (settings.DATABASES[database]['ENGINE'] == 'django_tenants.postgresql_backend' and not
                 django_is_in_test_mode()):
             raise CommandError("syncdb has been disabled, for database '{0}'. "
-                               "Use sync_schemas instead. Please read the "
+                               "Use migrate_schemas instead. Please read the "
                                "documentation if you don't know why "
                                "you shouldn't call syncdb directly!".format(database))
         super(Command, self).handle(*args, **options)

--- a/django_tenants/routers.py
+++ b/django_tenants/routers.py
@@ -7,21 +7,17 @@ class TenantSyncRouter(object):
     depending if we are syncing the shared apps or the tenant apps.
     """
 
-    def allow_migrate(self, db, model):
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
         # the imports below need to be done here else django <1.5 goes crazy
         # https://code.djangoproject.com/ticket/20704
         from django.db import connection
         from django_tenants.utils import get_public_schema_name, app_labels
 
         if connection.schema_name == get_public_schema_name():
-            if model._meta.app_label not in app_labels(settings.SHARED_APPS):
+            if app_label not in app_labels(settings.SHARED_APPS):
                 return False
         else:
-            if model._meta.app_label not in app_labels(settings.TENANT_APPS):
+            if app_label not in app_labels(settings.TENANT_APPS):
                 return False
 
         return None
-
-    def allow_syncdb(self, db, model):
-        # allow_syncdb was changed to allow_migrate in django 1.7
-        return self.allow_migrate(db, model)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -103,7 +103,7 @@ You also have to set where your tenant model is.
 
     TENANT_MODEL = "customers.Client" # app.Model
     
-Now run ``migrate_schemas --shared`` (``sync_schemas --shared`` if you're on Django 1.6 or older), this will create the shared apps on the ``public`` schema. Note: your database should be empty if this is the first time you're running this command.
+Now run ``migrate_schemas --shared``, this will create the shared apps on the ``public`` schema. Note: your database should be empty if this is the first time you're running this command.
 
 .. code-block:: bash
 
@@ -144,7 +144,7 @@ Optional Settings
 
     :Default: ``'True'``
     
-    Sets if the models will be synced directly to the last version and all migration subsequently faked. Useful in the cases where migrations can not be faked and need to be ran individually. Be aware that setting this to `False` may significantly slow down the process of creating tenants. Only relevant if `South <http://south.aeracode.org/>`_ is used.
+    Sets if the models will be synced directly to the last version and all migration subsequently faked. Useful in the cases where migrations can not be faked and need to be ran individually. Be aware that setting this to `False` may significantly slow down the process of creating tenants.
 
 Tenant View-Routing
 -------------------

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -29,7 +29,7 @@ Now we can create our first real tenant.
                     name='Fonzy Tenant',
                     paid_until='2014-12-05',
                     on_trial=True)
-    tenant.save() # sync_schemas automatically called, your tenant is ready to be used!
+    tenant.save() # migrate_schemas automatically called, your tenant is ready to be used!
     
 Because you have the tenant middleware installed, any request made to ``tenant.my-domain.com`` will now automatically set your PostgreSQL's ``search_path`` to ``tenant1, public``, making shared apps available too. The tenant will be made available at ``request.tenant``. By the way, the current schema is also available at ``connection.schema_name``, which is useful, for example, if you want to hook to any of django's signals. 
 
@@ -52,33 +52,12 @@ Every command except tenant_command runs by default on all tenants. You can also
 
 .. code-block:: bash
 
-    ./manage.py sync_schemas --schema=customer1
-
-sync_schemas    
-~~~~~~~~~~~~
-
-The command ``sync_schemas`` is the most important command on this app. The way it works is that it calls Django's ``syncdb`` in two different ways. First, it calls ``syncdb`` for the ``public`` schema, only syncing the shared apps. Then it runs ``syncdb`` for every tenant in the database, this time only syncing the tenant apps.
-
-.. warning::
-
-   You should never directly call ``syncdb``. We perform some magic in order to make ``syncdb`` only sync the appropriate apps.
-
-The options given to ``sync_schemas`` are passed to every ``syncdb``. So if you use South, you may find this handy
-
-.. code-block:: bash
-
-    ./manage.py sync_schemas --migrate
-
-You can also use the option ``--tenant`` to only sync tenant apps or ``--shared`` to only sync shared apps.
-
-.. code-block:: bash
-
-    ./manage.py sync_schemas --shared # will only sync the public schema
+    ./manage.py migrate_schemas --schema=customer1
 
 migrate_schemas    
 ~~~~~~~~~~~~~~~
 
-We've also packed south's migrate command in a compatible way with this app. It will also respect the ``SHARED_APPS`` and ``TENANT_APPS`` settings, so if you're migrating the ``public`` schema it will only migrate ``SHARED_APPS``. If you're migrating tenants, it will only migrate ``TENANT_APPS``.
+We've also packed the django migrate command in a compatible way with this app. It will also respect the ``SHARED_APPS`` and ``TENANT_APPS`` settings, so if you're migrating the ``public`` schema it will only migrate ``SHARED_APPS``. If you're migrating tenants, it will only migrate ``TENANT_APPS``.
 
 .. code-block:: bash
 


### PR DESCRIPTION
The signature of allow_migrate has changed in django 1.8. See:
https://docs.djangoproject.com/en/1.8/topics/db/multi-db/#allow_migrate
With the current implementation, the migrations do not work as expected. I ran into issues when I had a shared app with a migration that had a RunPython operation. That operation was executed on the tenant on creation as well as on migrate_schemas and failed obviously because of missing database tables. 
With the small update it runs fine again. 
I also removed some references to the removed sync_schemas commands in documentation. 