### PR TITLE
fix for django 1.8

### DIFF
--- a/django_tenants/routers.py
+++ b/django_tenants/routers.py
@@ -11,13 +11,17 @@ class TenantSyncRouter(object):
         # the imports below need to be done here else django <1.5 goes crazy
         # https://code.djangoproject.com/ticket/20704
         from django.db import connection
-        from django_tenants.utils import get_public_schema_name, app_labels
+        from django_tenants.utils import get_public_schema_name
+
+        # for INSTALLED_APPS we need a name
+        from django.apps import apps
+        app_name = apps.get_app_config(app_label).name
 
         if connection.schema_name == get_public_schema_name():
-            if app_label not in app_labels(settings.SHARED_APPS):
+            if app_name not in settings.SHARED_APPS:
                 return False
         else:
-            if app_label not in app_labels(settings.TENANT_APPS):
+            if app_name not in settings.TENANT_APPS:
                 return False
 
         return None


### PR DESCRIPTION
app_labels() was needed for old django versions, it was causing problems for django 1.8
e.g. 'kombu.transport.django' was converted to 'django' and obviously not handled. Since we don't want app_lables() anymore we need app_name