### PR TITLE
Parallel migrations -- fix for tests

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -53,9 +53,10 @@ class MigrateSchemasCommand(SyncCommon):
                 else:
                     tenants = [self.schema_name]
             else:
-                tenants = [
-                    t.schema_name for t in get_tenant_model().objects.only('schema_name').exclude(schema_name=self.PUBLIC_SCHEMA_NAME)
-                ]
+                tenants = get_tenant_model().objects.only(
+                    'schema_name').exclude(
+                    schema_name=self.PUBLIC_SCHEMA_NAME).values_list(
+                    'schema_name', flat=True)
 
             executor.run_migrations(tenants=tenants)
 

--- a/django_tenants/migration_executors/__init__.py
+++ b/django_tenants/migration_executors/__init__.py
@@ -1,10 +1,12 @@
+import os
+
 from .base import MigrationExecutor
 from .multiproc import MultiprocessingExecutor
 from .standard import StandardExecutor
 
 
 def get_executor(codename=None):
-    codename = codename or StandardExecutor.codename
+    codename = codename or os.environ.get('EXECUTOR', StandardExecutor.codename)
 
     for klass in MigrationExecutor.__subclasses__():
         if klass.codename == codename:

--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -29,6 +29,10 @@ def run_migrations(args, options, executor_codename, schema_name):
     if int(options.get('verbosity', 1)) >= 1:
         stdout.write(style.NOTICE("=== Starting migration"))
     MigrateCommand(stdout=stdout, stderr=stderr).execute(*args, **options)
+
+    connection.close()
+    connection.connection = None
+
     connection.set_schema_to_public()
 
 

--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -4,7 +4,7 @@ from django.core.management.commands.migrate import Command as MigrateCommand
 from django_tenants.utils import get_public_schema_name
 
 
-def run_migrations(args, options, schema_name):
+def run_migrations(args, options, executor_codename, schema_name):
     from django.core.management import color
     from django.core.management.base import OutputWrapper
     from django.db import connection
@@ -12,7 +12,8 @@ def run_migrations(args, options, schema_name):
     style = color.color_style()
 
     def style_func(msg):
-        return '[%s] %s' % (
+        return '[%s:%s] %s' % (
+            style.NOTICE(executor_codename),
             style.NOTICE(schema_name),
             msg
         )

--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -11,6 +11,9 @@ def run_migrations(args, options, executor_codename, schema_name):
 
     style = color.color_style()
 
+    connection.close()
+    connection.connection = None
+
     def style_func(msg):
         return '[%s:%s] %s' % (
             style.NOTICE(executor_codename),

--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -11,9 +11,6 @@ def run_migrations(args, options, executor_codename, schema_name):
 
     style = color.color_style()
 
-    connection.close()
-    connection.connection = None
-
     def style_func(msg):
         return '[%s:%s] %s' % (
             style.NOTICE(executor_codename),

--- a/django_tenants/migration_executors/multiproc.py
+++ b/django_tenants/migration_executors/multiproc.py
@@ -13,7 +13,7 @@ class MultiprocessingExecutor(MigrationExecutor):
         tenants = tenants or []
 
         if self.PUBLIC_SCHEMA_NAME in tenants:
-            run_migrations(self.args, self.options, self.PUBLIC_SCHEMA_NAME)
+            run_migrations(self.args, self.options, self.codename, self.PUBLIC_SCHEMA_NAME)
             tenants.pop(tenants.index(self.PUBLIC_SCHEMA_NAME))
 
         if tenants:
@@ -38,7 +38,8 @@ class MultiprocessingExecutor(MigrationExecutor):
             run_migrations_p = functools.partial(
                 run_migrations,
                 self.args,
-                self.options
+                self.options,
+                self.codename
             )
             p = multiprocessing.Pool(processes=processes)
             p.map(

--- a/django_tenants/migration_executors/multiproc.py
+++ b/django_tenants/migration_executors/multiproc.py
@@ -30,9 +30,7 @@ class MultiprocessingExecutor(MigrationExecutor):
 
             from django.db import connection
 
-            # Let every process make its connection, but don't close the
-            # main connection
-            c = connection.connection
+            connection.close()
             connection.connection = None
 
             run_migrations_p = functools.partial(
@@ -47,6 +45,3 @@ class MultiprocessingExecutor(MigrationExecutor):
                 tenants,
                 chunks
             )
-
-            # Revert the original connection
-            connection.connection = c

--- a/django_tenants/migration_executors/standard.py
+++ b/django_tenants/migration_executors/standard.py
@@ -8,8 +8,8 @@ class StandardExecutor(MigrationExecutor):
         tenants = tenants or []
 
         if self.PUBLIC_SCHEMA_NAME in tenants:
-            run_migrations(self.args, self.options, self.PUBLIC_SCHEMA_NAME)
+            run_migrations(self.args, self.options, self.codename, self.PUBLIC_SCHEMA_NAME)
             tenants.pop(tenants.index(self.PUBLIC_SCHEMA_NAME))
 
         for schema_name in tenants:
-            run_migrations(self.args, self.options, schema_name)
+            run_migrations(self.args, self.options, self.codename, schema_name)

--- a/django_tenants/test/cases.py
+++ b/django_tenants/test/cases.py
@@ -1,39 +1,32 @@
-import os
-
 from django.core.management import call_command
 from django.db import connection
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from django_tenants.utils import get_tenant_model, get_tenant_domain_model, get_public_schema_name
 
 
-class TenantTestCase(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.sync_shared()
-        cls.tenant = get_tenant_model()(schema_name='test')
-        cls.tenant.save(verbosity=0)  # todo: is there any way to get the verbosity from the test command here?
+class TenantTestCase(TransactionTestCase):
+    def setUp(self):
+        self.sync_shared()
+        self.tenant = get_tenant_model()(schema_name='test')
+        self.tenant.save(verbosity=0)  # todo: is there any way to get the verbosity from the test command here?
 
         # Set up domain
         tenant_domain = 'tenant.test.com'
-        domain = get_tenant_domain_model()(tenant=cls.tenant, domain=tenant_domain)
-        domain.save()
+        self.domain = get_tenant_domain_model()(tenant=self.tenant, domain=tenant_domain)
+        self.domain.save()
 
-        connection.set_tenant(cls.tenant)
+        connection.set_tenant(self.tenant)
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         connection.set_schema_to_public()
-        cls.tenant.delete()
-
-        cursor = connection.cursor()
-        cursor.execute('DROP SCHEMA test CASCADE')
+        self.domain.delete()
+        self.tenant.delete(force_drop=True)
 
     @classmethod
     def sync_shared(cls):
         call_command('migrate_schemas',
                      schema_name=get_public_schema_name(),
                      interactive=False,
-                     executor=os.environ.get('EXECUTOR', 'standard'),
                      verbosity=0)
 

--- a/django_tenants/tests/test_routes.py
+++ b/django_tenants/tests/test_routes.py
@@ -16,11 +16,23 @@ class RoutesTestCase(BaseTestCase):
                                 'django.contrib.contenttypes',
                                 'django.contrib.auth', )
         settings.INSTALLED_APPS = settings.SHARED_APPS + settings.TENANT_APPS
+        cls.available_apps = settings.INSTALLED_APPS
         cls.sync_shared()
         cls.public_tenant = get_tenant_model()(schema_name=get_public_schema_name())
         cls.public_tenant.save()
         cls.public_domain = get_tenant_domain_model()(domain='test.com', tenant=cls.public_tenant)
         cls.public_domain.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        from django.db import connection
+
+        connection.set_schema_to_public()
+
+        cls.public_domain.delete()
+        cls.public_tenant.delete()
+
+        super(RoutesTestCase, cls).tearDownClass()
 
     def setUp(self):
         super(RoutesTestCase, self).setUp()
@@ -32,6 +44,16 @@ class RoutesTestCase(BaseTestCase):
         self.tenant.save()
         self.domain = get_tenant_domain_model()(tenant=self.tenant, domain=self.tenant_domain)
         self.domain.save()
+
+    def tearDown(self):
+        from django.db import connection
+
+        connection.set_schema_to_public()
+
+        self.domain.delete()
+        self.tenant.delete(force_drop=True)
+
+        super(RoutesTestCase, self).tearDown()
 
     def test_tenant_routing(self):
         """

--- a/django_tenants/tests/testcases.py
+++ b/django_tenants/tests/testcases.py
@@ -1,14 +1,12 @@
-import os
-
+from django.db import connection
 from django.conf import settings
 from django.core.management import call_command
-from django.db import connection
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from django_tenants.utils import get_public_schema_name
 
 
-class BaseTestCase(TestCase):
+class BaseTestCase(TransactionTestCase):
     """
     Base test case that comes packed with overloaded INSTALLED_APPS,
     custom public tenant, and schemas cleanup on tearDown.
@@ -24,12 +22,14 @@ class BaseTestCase(TestCase):
                                 'django.contrib.auth', )
         settings.INSTALLED_APPS = settings.SHARED_APPS + settings.TENANT_APPS
 
+        cls.available_apps = settings.INSTALLED_APPS
+
         # Django calls syncdb by default for the test database, but we want
         # a blank public schema for this set of tests.
-        connection.set_schema_to_public()
-        cursor = connection.cursor()
-        cursor.execute('DROP SCHEMA %s CASCADE; CREATE SCHEMA %s;'
-                       % (get_public_schema_name(), get_public_schema_name(), ))
+        #connection.set_schema_to_public()
+        #with connection.cursor() as cursor:
+        #    cursor.execute('DROP SCHEMA %s CASCADE; CREATE SCHEMA %s;'
+        #                   % (get_public_schema_name(), get_public_schema_name(), ))
         super(BaseTestCase, cls).setUpClass()
 
     def setUp(self):
@@ -49,5 +49,4 @@ class BaseTestCase(TestCase):
         call_command('migrate_schemas',
                      schema_name=get_public_schema_name(),
                      interactive=False,
-                     executor=os.environ.get('EXECUTOR', 'standard'),
                      verbosity=0)

--- a/django_tenants/tests/testcases.py
+++ b/django_tenants/tests/testcases.py
@@ -24,12 +24,6 @@ class BaseTestCase(TransactionTestCase):
 
         cls.available_apps = settings.INSTALLED_APPS
 
-        # Django calls syncdb by default for the test database, but we want
-        # a blank public schema for this set of tests.
-        #connection.set_schema_to_public()
-        #with connection.cursor() as cursor:
-        #    cursor.execute('DROP SCHEMA %s CASCADE; CREATE SCHEMA %s;'
-        #                   % (get_public_schema_name(), get_public_schema_name(), ))
         super(BaseTestCase, cls).setUpClass()
 
     def setUp(self):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 pushd dts_test_project
 
 EXECUTORS=( standard multiprocessing )

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,8 @@
 
 pushd dts_test_project
 
-EXECUTOR=standard python manage.py test django_tenants.tests
+EXECUTORS=( standard multiprocessing )
 
-EXECUTOR=multiprocessing python manage.py test django_tenants.tests
+for executor in "${EXECUTORS[@]}"; do
+    EXECUTOR=$executor python manage.py test django_tenants.tests
+done


### PR DESCRIPTION
I discovered that tests weren't run correctly for migration executor. The `os.environ['EXECUTOR']` variable wasn't taken into account properly. This was fixed in the first commit in the series:

https://github.com/tomturner/django-tenants/commit/d4c6a6c8e90c249694838381ce76a239c004041c

Here I added reporting which executor is used:

https://github.com/tomturner/django-tenants/commit/06e4ac55543740d44cf9e14a32d0544dd42b7499

Unfortunately, it turned out that tests failed for the `multiprocessing` executor. This is due to incorrect `connection` handling, proper `close()` needs to be made. This change, however small, opened up a Pandora's box in tests -- we are using `django.test.TestCase` which doesn't handle `connection.close` properly (because of performance reasons, it applies migrations and then does a rollback). So the journey began to rewrite this to `django.test.TransactionTestCase` (please read more here https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.TransactionTestCase where it explicitly states about `TestCase` using `commit` and `rollback`).

The result of this journey is commit

https://github.com/tomturner/django-tenants/commit/4e2802dee5394df195de880cc27d9bbe6d1d6dd9

in which the `standard` executor passes again with `TransactionTestCase`. After that fixing `multiprocessing` was easy.

You can see the detailed test output here:

https://travis-ci.org/CGenie/django-tenants