### PR TITLE
Fix `PG_EXTRA_SEARCH_PATHS` setting checking when no migrations were sy…

### DIFF
--- a/django_tenants/tests/test_settings.py
+++ b/django_tenants/tests/test_settings.py
@@ -1,0 +1,17 @@
+from django.apps import apps
+from django.db import connection
+from django.test import TransactionTestCase
+from django.test.utils import override_settings
+
+from django_tenants.utils import get_public_schema_name
+
+
+class TestSettings(TransactionTestCase):
+    @override_settings(PG_EXTRA_SEARCH_PATHS=['hstore'])
+    def test_PG_EXTRA_SEARCH_PATHS(self):
+        del apps.all_models['django_tenants']
+        c = connection.cursor()
+        c.execute('DROP SCHEMA {0} CASCADE; CREATE SCHEMA {0};'.format(
+            get_public_schema_name()
+        ))
+        apps.set_installed_apps(['customers', 'django_tenants'])

--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -117,3 +117,4 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+


### PR DESCRIPTION
…nced

This is described in the added `test_settings.py` -- when running `migrate_schemas` initially, with an empty database, there is an error that 

```python
get_tenant_model().objects.all().values_list('schema_name', flat=True))
```

cannot be fetched, because the model's table is not created yet.