### PR TITLE
Fix atomic transaction behavior with connection.close in executors

### DIFF
--- a/django_tenants/migration_executors/multiproc.py
+++ b/django_tenants/migration_executors/multiproc.py
@@ -37,7 +37,8 @@ class MultiprocessingExecutor(MigrationExecutor):
                 run_migrations,
                 self.args,
                 self.options,
-                self.codename
+                self.codename,
+                allow_atomic=False
             )
             p = multiprocessing.Pool(processes=processes)
             p.map(

--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -85,7 +85,7 @@ class TenantMixin(models.Model):
             try:
                 self.create_schema(check_if_exists=True, verbosity=verbosity)
                 post_schema_sync.send(sender=TenantMixin, tenant=self)
-            except:
+            except Exception as e:
                 # We failed creating the tenant, delete what we created and
                 # re-raise the exception
                 self.delete(force_drop=True)


### PR DESCRIPTION
Closes tomturner/django-tenants#48