### PR TITLE
TemplateDoesNotExist has been moved in django

### DIFF
--- a/django_tenants/template_loaders.py
+++ b/django_tenants/template_loaders.py
@@ -6,7 +6,8 @@ multi-tenant setting
 import hashlib
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.template.base import TemplateDoesNotExist, Template
+from django.template.base import Template
+from django.template.exceptions import TemplateDoesNotExist
 from django.utils.encoding import force_bytes
 from django.utils._os import safe_join
 from django.db import connection


### PR DESCRIPTION
The TemplateDoesNotExist exception has been moved from django.template.base to django.template.exceptions; changed the import.