### PR TITLE
fix tenants links in examples/tenant_tutorial and get_primary_domain() return

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -141,7 +141,7 @@ class TenantMixin(models.Model):
         """
         try:
             domain = self.domains.get(is_primary=True)
-            return domain
+            return domain.domain
         except get_tenant_domain_model().DoesNotExist:
             return None
 

--- a/examples/tenant_tutorial/templates/base.html
+++ b/examples/tenant_tutorial/templates/base.html
@@ -41,15 +41,15 @@
 <div id="footer">
   <p style="float: left;">Current Tenant:
       {% if request.tenant %}
-      <a href="http://{{ request.tenant.domain_urls }}:8000">{{ request.tenant.name }}</a>
-      (<code>{{ request.tenant.schema_name }}</code>, <code>{{ request.tenant.domain_urls }}</code>).
+      <a href="http://{{ request.tenant.get_primary_domain }}:8000">{{ request.tenant.name }}</a>
+      (<code>{{ request.tenant.schema_name }}</code>, <code>{{ request.tenant.get_primary_domain }}</code>).
 
       Available Tenants:
       {% else %}
       None.
       {% endif %}
   {% for tenant in tenants_list %}
-      <a href="http://{{ tenant.domain_url }}:8000">{{ tenant.name }}</a> &middot;
+      <a href="http://{{ tenant.get_primary_domain }}:8000">{{ tenant.name }}</a> &middot;
   {% endfor %}</p>
   <p style="float: right;">
     <a href="https://github.com/tomturner/django-tenants">django-tenants</a> &middot; <a href="https://django-tenants.readthedocs.org/en/latest/">Documentation</a>

--- a/examples/tenant_tutorial/templates/index_public.html
+++ b/examples/tenant_tutorial/templates/index_public.html
@@ -73,11 +73,14 @@ Client(schema_name='public',
     <p>We can now add tenants using these URLs and our project will be able to find them and identify them as our tenants. Back to the django shell:</p>
 
 <pre>$ ./manage.py shell</pre>
-<pre>from customers.models import Client</pre>
+<pre>from customers.models import Client, Domain</pre>
 <pre>
-Client(schema_name='tenant1',
+tenant = Client(schema_name='tenant1',
     name='Tenant1 - Awesome',
-    description='Our first real tenant, awesome!').save()</pre>
+    description='Our first real tenant, awesome!')
+
+tenant.save()
+</pre>
     <p>Saving a tenant that didn't exist before will create their schema and sync <code>TENANT_APPS</code> automatically. You should see
     the following lines as the result.</p>
   <pre>Operations to perform:
@@ -91,11 +94,31 @@ Running migrations:
   Applying contenttypes.0001_initial... OK
   Applying auth.0001_initial... OK
   Applying sessions.0001_initial... OK</pre>
+
+Now add one domain to your tenant.
+
+<pre>
+domain = Domain()
+domain.domain = 'tenant1.trendy-sass.com'
+domain.tenant = tenant
+domain.is_primary = True
+domain.save()
+</pre>
+
     <p>This means your tenant was installed successfully. Now create the second tenant.</p>
 <pre>
-Client(schema_name='tenant2',
+tenant = Client(schema_name='tenant2',
     name='Tenant2 - Even Awesome-r',
-    description='A second tenant, even more awesome!').save()</pre>
+    description='A second tenant, even more awesome!')
+
+tenant.save()
+
+domain = Domain()
+domain.domain = 'tenant2.trendy-sass.com'
+domain.tenant = tenant
+domain.is_primary = True
+domain.save()
+</pre>
 
     <p>Now try visiting <a href="http://tenant1.trendy-sass.com:8000">tenant1.trendy-sass.com</a> and
         <a href="http://tenant2.trendy-sass.com:8000">tenant2.trendy-sass.com</a> or refresh this page.</p>
@@ -105,9 +128,9 @@ Client(schema_name='tenant2',
     <h3>Where to go from here</h3>
     <p>There are some interesting features that we did not cover.</p>
     <ul>
-        <li><a href="https://django-tenant-schemas.readthedocs.org/en/latest/install.html#south-migrations">South Migrations</a>. This app supports <code>South</code> migrations.</li>
-        <li><a href="https://django-tenant-schemas.readthedocs.org/en/latest/install.html#tenant-view-routing">Tenant View-Routing</a>. Serve different views for the same path. (this tutorial makes use of this feature)</li>
-        <li><a href="https://django-tenant-schemas.readthedocs.org/en/latest/use.html#management-commands">Management Commands</a>. Run a command for a particular tenant.</li>
+        <li><a href="https://django-tenants.readthedocs.org/en/latest/install.html#south-migrations">South Migrations</a>. This app supports <code>South</code> migrations.</li>
+        <li><a href="https://django-tenants.readthedocs.org/en/latest/install.html#tenant-view-routing">Tenant View-Routing</a>. Serve different views for the same path. (this tutorial makes use of this feature)</li>
+        <li><a href="https://django-tenants.readthedocs.org/en/latest/use.html#management-commands">Management Commands</a>. Run a command for a particular tenant.</li>
     </ul>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Hi, Tom. 
I made a patch that fixes the return of the domain name and also fixes the tutorial steps.
Thanks.