### PR TITLE
Added reverse for tenants. #87

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models, connection, transaction
 from django.core.management import call_command
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.urlresolvers import resolve, reverse
 
 from .postgresql_backend.base import _check_schema_name
 from .signals import post_schema_sync, schema_needs_to_be_sync
@@ -144,6 +146,16 @@ class TenantMixin(models.Model):
             return domain
         except get_tenant_domain_model().DoesNotExist:
             return None
+
+    def reverse(self, request, view_name):
+        """
+        Returns the URL of this tenant.
+        """
+        url = 'https://' if request.is_secure() else 'http://'
+        url += str(self.schema_name) + '.'
+        url += get_current_site(request).domain
+        url += reverse(view_name)
+        return url
 
 
 class DomainMixin(models.Model):

--- a/dts_test_project/customers/models.py
+++ b/dts_test_project/customers/models.py
@@ -7,6 +7,15 @@ class Client(TenantMixin):
     description = models.TextField(max_length=200, blank=True, null=True)
     created_on = models.DateField(auto_now_add=True)
 
+    def reverse(self, request, view_name):
+        """
+        If you have different implementation of reserve from what the
+        Django-Tenants library uses (A.k.a. Sites Framework) then you can write
+        your own override here.
+        """
+        # Write your own custom code else use existing code.
+        return super( Client, self ).reverse(request, view_name)
+
 
 class Domain(DomainMixin):
     pass


### PR DESCRIPTION
The following code grants the Tenant models (which inherit **TenantMixin**) to reverse views to specific URLS with sub-domains handling using Django's existing Sites Framework. Code for issue #87.