### PR TITLE
Django 1.10 support changes

### DIFF
--- a/django_tenants/management/commands/__init__.py
+++ b/django_tenants/management/commands/__init__.py
@@ -113,7 +113,6 @@ class TenantWrappedCommand(InteractiveTenantOption, BaseCommand):
     def __new__(cls, *args, **kwargs):
         obj = super(TenantWrappedCommand, cls).__new__(cls, *args, **kwargs)
         obj.command_instance = obj.COMMAND()
-        # obj.option_list = obj.command_instance.option_list
         return obj
 
     def handle(self, *args, **options):

--- a/django_tenants/management/commands/__init__.py
+++ b/django_tenants/management/commands/__init__.py
@@ -113,7 +113,7 @@ class TenantWrappedCommand(InteractiveTenantOption, BaseCommand):
     def __new__(cls, *args, **kwargs):
         obj = super(TenantWrappedCommand, cls).__new__(cls, *args, **kwargs)
         obj.command_instance = obj.COMMAND()
-        obj.option_list = obj.command_instance.option_list
+        # obj.option_list = obj.command_instance.option_list
         return obj
 
     def handle(self, *args, **options):

--- a/django_tenants/management/commands/clone_tenant.py
+++ b/django_tenants/management/commands/clone_tenant.py
@@ -18,22 +18,14 @@ class Command(BaseCommand):
     domain_fields = [field for field in get_tenant_domain_model()._meta.fields
                       if field.editable and not field.primary_key]
 
-    def __init__(self, *args, **kwargs):
-        super(Command, self).__init__(*args, **kwargs)
-
-        self.option_list = BaseCommand.option_list
-
-        self.option_list += (make_option('--clone_from',
-                                         help='Specifies which schema to clone.'), )
+    def add_arguments(self, parser):
+        parser.add_argument('--clone_from', help='Specifies which schema to clone.')
 
         for field in self.tenant_fields:
-            self.option_list += (make_option('--%s' % field.name,
-                                             help='Specifies the %s for tenant.' % field.name), )
+            parser.add_argument('--%s' % field.name, help='Specifies the %s for tenant.' % field.name)
 
         for field in self.domain_fields:
-            self.option_list += (make_option('--%s' % field.name,
-                                             help="Specifies the %s for the tenant's domain." % field.name), )
-
+            parser.add_argument('--%s' % field.name, help="Specifies the %s for the tenant's domain." % field.name)
 
     def handle(self, *args, **options):
 

--- a/django_tenants/management/commands/create_tenant.py
+++ b/django_tenants/management/commands/create_tenant.py
@@ -17,21 +17,18 @@ class Command(BaseCommand):
     domain_fields = [field for field in get_tenant_domain_model()._meta.fields
                       if field.editable and not field.primary_key]
 
-    def __init__(self, *args, **kwargs):
-        super(Command, self).__init__(*args, **kwargs)
-
-        self.option_list = BaseCommand.option_list
-
+    def add_arguments(self, parser):
         for field in self.tenant_fields:
-            self.option_list += (make_option('--%s' % field.name,
-                                             help='Specifies the %s for tenant.' % field.name), )
+            parser.add_argument('--%s' % field.name,
+                                        help='Specifies the %s for tenant.' % field.name)
 
         for field in self.domain_fields:
-            self.option_list += (make_option('--%s' % field.name,
-                                             help="Specifies the %s for the tenant's domain." % field.name), )
+            parser.add_argument('--%s' % field.name,
+                                        help="Specifies the %s for the tenant's domain." % field.name)
 
-        self.option_list += (make_option('-s', action="store_true",
-                                         help='Create a superuser afterwards.'),)
+        parser.add_argument('-s', action="store_true",
+                                        help='Create a superuser afterwards.')
+
 
     def handle(self, *args, **options):
 

--- a/django_tenants/middleware.py
+++ b/django_tenants/middleware.py
@@ -2,10 +2,11 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.shortcuts import get_object_or_404
+from django.utils.deprecation import MiddlewareMixin
 from .utils import get_tenant_model, remove_www, get_public_schema_name, get_tenant_domain_model
 
 
-class TenantMiddleware(object):
+class TenantMiddleware(MiddlewareMixin):
     """
     This middleware should be placed at the very top of the middleware stack.
     Selects the proper database schema using the request host. Can fail in


### PR DESCRIPTION
Upgraded TenantMiddleware to Django 1.10 new-style middleware contributes to issue  #91 
- Updated TenantMiddleware
[New-style middleware](https://docs.djangoproject.com/en/1.10/releases/1.10/)
[Upgrading pre-Django 1.10-style middleware](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)

- Updated TenantWrappedCommand to remove deprecated option_list
see [Extending management command arguments through Command.option_list](https://docs.djangoproject.com/en/1.10/releases/1.8/#extending-management-command-arguments-through-command-option-list)

