### PR TITLE
Fix for #114

### DIFF
--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -111,6 +111,8 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         # optionally limit the number of executions - under load, the execution
         # of `set search_path` can be quite time consuming
         if (not get_limit_set_calls()) or not self.search_path_set or self._previous_cursor != cursor:
+            # Store the cursor pointer to check if it has changed since we 
+            # last validated.
             self._previous_cursor = cursor
             # Actual search_path modification for the cursor. Database will
             # search schemata from left to right when looking for the object

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -43,6 +43,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
     Adds the capability to manipulate the search_path using set_tenant and set_schema_name
     """
     include_public_schema = True
+    _previous_cursor = None
 
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
@@ -109,7 +110,8 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
 
         # optionally limit the number of executions - under load, the execution
         # of `set search_path` can be quite time consuming
-        if (not get_limit_set_calls()) or not self.search_path_set:
+        if (not get_limit_set_calls()) or not self.search_path_set or self._previous_cursor != cursor:
+            self._previous_cursor = cursor
             # Actual search_path modification for the cursor. Database will
             # search schemata from left to right when looking for the object
             # (table, index, sequence, etc.).


### PR DESCRIPTION
This fix introduces a validation of the cursor at the `DatabaseWrapper` to make sure the search_paths are always applied even if we get a different cursor pointer