### PR TITLE
Adding a safety check inside tenant model save and delete for compatibilty

### DIFF
--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -70,7 +70,7 @@ DATABASES = {
         'ENGINE': 'django_tenants.postgresql_backend',
         'NAME': 'dts_test_project',
         'USER': 'postgres',
-        'PASSWORD': 'root',
+        'PASSWORD': os.environ.get('DATABASE_PASSWORD', 'root'),
         'HOST': os.environ.get('DATABASE_HOST', 'localhost'),
         'PORT': '',
     }


### PR DESCRIPTION
Hello!

This PR concerns two changes, that are minor and do not have direct impact on the project. I'll try to explain them both in detail.

The entire test suite is passing.

## Safety check inside save/delete methods

Inside the TenantMixIn model, I've added a few safety checks. These safety checks prevent the direct usage of ```connection.schema_name```, unless if it really exists.

The rationale behind this are two:

1. We have a project that needs to support ```both``` ways. With and without tenants. Everything is fine on our side, except that when we are working on a tenantless mode, the ```save``` method and ```delete``` method try to do direct usage of ```connection.schema_name``` and everything blows up on our face :smile: 

2. We currently test a few of our applications with two different settings. PostgreSQL with tenants (which takes a long time, it's a big suite) and SQLite (without tenants, which is **way faster**). The same problem occurs.

We already have overriden the save and delete methods on our tenant and we don't have this problem in production or our project at all, but I thought it would be a "nice to have" if other people find the same requirements.

## Changing the dts_test_project_settings

1. While trying to run the tests, we have encountered that it was not possible to customize a few of the settings we have. So instead of changing my own password so we could run these, I've added the option to customize the command with environment variables, the same way as the database can be customized.

