### PR TITLE
Fix django 1.9 and 1.10 problem with the commands

### DIFF
--- a/django_tenants/management/commands/clone_tenant.py
+++ b/django_tenants/management/commands/clone_tenant.py
@@ -1,3 +1,4 @@
+import django
 from optparse import make_option
 from django.core import exceptions
 from django.core.management.base import BaseCommand
@@ -21,7 +22,10 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)
 
-        self.option_list = BaseCommand.option_list
+        self.option_list = ()
+
+        if django.VERSION <= (1, 10, 0):
+            self.option_list = BaseCommand.option_list
 
         self.option_list += (make_option('--clone_from',
                                          help='Specifies which schema to clone.'), )

--- a/django_tenants/management/commands/syncdb.py
+++ b/django_tenants/management/commands/syncdb.py
@@ -1,18 +1,28 @@
-from django.core.management.base import CommandError
-from django.conf import settings
-from django_tenants.utils import django_is_in_test_mode
-
-from django.core.management.commands import syncdb
+import django
+from django.core.management.base import BaseCommand, CommandError
 
 
-class Command(syncdb.Command):
+if django.VERSION < (1, 9, 0):
+	from django.conf import settings
+	from django_tenants.utils import django_is_in_test_mode
 
-    def handle(self, *args, **options):
-        database = options.get('database', 'default')
-        if (settings.DATABASES[database]['ENGINE'] == 'django_tenants.postgresql_backend' and not
-                django_is_in_test_mode()):
-            raise CommandError("syncdb has been disabled, for database '{0}'. "
-                               "Use migrate_schemas instead. Please read the "
-                               "documentation if you don't know why "
-                               "you shouldn't call syncdb directly!".format(database))
-        super(Command, self).handle(*args, **options)
+	from django.core.management.commands import syncdb
+
+
+	class Command(syncdb.Command):
+
+	    def handle(self, *args, **options):
+	        database = options.get('database', 'default')
+	        if (settings.DATABASES[database]['ENGINE'] == 'django_tenants.postgresql_backend' and not
+	                django_is_in_test_mode()):
+	            raise CommandError("syncdb has been disabled, for database '{0}'. "
+	                               "Use migrate_schemas instead. Please read the "
+	                               "documentation if you don't know why "
+	                               "you shouldn't call syncdb directly!".format(database))
+	        super(Command, self).handle(*args, **options)
+else:
+
+	class Command(BaseCommand):
+
+	    def handle(self, *args, **options):
+	        raise CommandError("syncdb has been removed in django 1.9")


### PR DESCRIPTION
In the `clone_tenant.py` command there was a problem with `BaseCommand.option_list` that doesn't exists in django 1.10.+ . Also, when the commands were loaded by some method like `django.core.management.load_command_class` using `get_commands` from the same module, if the version was not django 1.8.x or less, the `syncdb.py` command died because the django syncdb command was removed in django 1.9.