### PR TITLE
Update docker, tests, and test models for Django2 and Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ MAINTAINER Przemek Kamiński <cgenie@gmail.com>
 
 RUN apt-get update && apt-get -y upgrade
 
-RUN apt-get -y install python-pip python-psycopg2 git
+RUN apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git
 
 WORKDIR /code
 
 ADD . /code
 
-RUN python setup.py develop
+RUN python3 setup.py develop

--- a/dts_test_project/customers/migrations/0001_initial.py
+++ b/dts_test_project/customers/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('domain', models.CharField(unique=True, max_length=253, db_index=True)),
                 ('is_primary', models.BooleanField(default=True)),
-                ('tenant', models.ForeignKey(related_name='domains', to='customers.Client')),
+                ('tenant', models.ForeignKey(related_name='domains', to='customers.Client', on_delete=models.deletion.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/dts_test_project/dts_test_app/migrations/0001_initial.py
+++ b/dts_test_project/dts_test_app/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
             name='ModelWithFkToPublicUser',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.deletion.CASCADE)),
             ],
         ),
     ]

--- a/dts_test_project/dts_test_app/models.py
+++ b/dts_test_project/dts_test_app/models.py
@@ -13,4 +13,4 @@ class DummyModel(models.Model):
 
 
 class ModelWithFkToPublicUser(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL)
+    user = models.ForeignKey(AUTH_USER_MODEL, on_delete=models.CASCADE)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -21,5 +21,5 @@ pushd dts_test_project
 EXECUTORS=( standard multiprocessing )
 
 for executor in "${EXECUTORS[@]}"; do
-    EXECUTOR=$executor python manage.py test django_tenants.tests
+    EXECUTOR=$executor python3 manage.py test django_tenants.tests
 done


### PR DESCRIPTION
Django2 is a requirement in `setup.py` so the following had to be changed:

- use python3 (affects `Dockerfile` and `run_tests.sh`)
- add `on_delete` to models