### PR TITLE
Fix TENANT_LIMIT_SET_CALLS implementation

### DIFF
--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -47,7 +47,6 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
     Adds the capability to manipulate the search_path using set_tenant and set_schema_name
     """
     include_public_schema = True
-    _previous_cursor = None
 
     def __init__(self, *args, **kwargs):
         self.search_path_set = None
@@ -121,10 +120,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
 
         # optionally limit the number of executions - under load, the execution
         # of `set search_path` can be quite time consuming
-        if (not get_limit_set_calls()) or not self.search_path_set or self._previous_cursor != cursor:
-            # Store the cursor pointer to check if it has changed since we 
-            # last validated.
-            self._previous_cursor = cursor
+        if (not get_limit_set_calls()) or not self.search_path_set:
             # Actual search_path modification for the cursor. Database will
             # search schemata from left to right when looking for the object
             # (table, index, sequence, etc.).

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import connection, transaction
+from django.test.utils import override_settings
 
 from dts_test_app.models import DummyModel, ModelWithFkToPublicUser
 from django_tenants.test.cases import TenantTestCase
@@ -168,17 +169,66 @@ class TenantDataAndSettingsTest(BaseTestCase):
         DummyModel(name="awesome!").save()
 
         # switch temporarily to tenant2's path
-        with tenant_context(tenant2):
-            # add some data, 3 DummyModels for tenant2
-            DummyModel(name="Man,").save()
-            DummyModel(name="testing").save()
-            DummyModel(name="is great!").save()
+        with self.assertNumQueries(6):
+            with tenant_context(tenant2):
+                # add some data, 3 DummyModels for tenant2
+                DummyModel(name="Man,").save()
+                DummyModel(name="testing").save()
+                DummyModel(name="is great!").save()
 
         # we should be back to tenant1's path, test what we have
-        self.assertEqual(2, DummyModel.objects.count())
+        with self.assertNumQueries(2):
+            self.assertEqual(2, DummyModel.objects.count())
 
         # switch back to tenant2's path
-        with tenant_context(tenant2):
+        with self.assertNumQueries(2):
+            with tenant_context(tenant2):
+                self.assertEqual(3, DummyModel.objects.count())
+
+        self.created = [domain2, domain1, tenant2, tenant1]
+
+    @override_settings(TENANT_LIMIT_SET_CALLS=True)
+    def test_switching_search_path_limited_calls(self):
+        tenant1 = get_tenant_model()(schema_name='tenant1')
+        tenant1.save()
+
+        domain1 = get_tenant_domain_model()(tenant=tenant1, domain='something.test.com')
+        domain1.save()
+
+        connection.set_schema_to_public()
+
+        tenant2 = get_tenant_model()(schema_name='tenant2')
+        tenant2.save()
+
+        domain2 = get_tenant_domain_model()(tenant=tenant2, domain='example.com')
+        domain2.save()
+
+        # set path is not executed when setting tenant so 0 queries expected
+        with self.assertNumQueries(0):
+            connection.set_tenant(tenant1)
+
+        # switch temporarily to tenant2's path
+        # 1 query to set search path + 3 to save data
+        with self.assertNumQueries(4):
+            with tenant_context(tenant2):
+                DummyModel(name="Man,").save()
+                DummyModel(name="testing").save()
+                DummyModel(name="is great!").save()
+
+        # 0 queries as search path not set here
+        with self.assertNumQueries(0):
+            connection.set_tenant(tenant1)
+
+        # 1 set search path + 1 count
+        with self.assertNumQueries(2):
+            self.assertEqual(0, DummyModel.objects.count())
+
+        # 0 queries as search path not set here
+        with self.assertNumQueries(0):
+            connection.set_tenant(tenant2)
+
+        # 1 set search path + 1 count
+        with self.assertNumQueries(2):
             self.assertEqual(3, DummyModel.objects.count())
 
         self.created = [domain2, domain1, tenant2, tenant1]


### PR DESCRIPTION
The change introduced in #115 broke the `TENANT_LIMIT_SET_CALLS` because the `DatabaseWrapper` creates a new cursor every time and so the check `self._previous_cursor != cursor` is never false.
This behaviour is described in [PEP 249](https://www.python.org/dev/peps/pep-0249/#connection-methods):
> .cursor()
Return a new Cursor Object using the connection.

and can be seen in the underlying implementation (in [django.db.backends.base](https://github.com/django/django/blob/master/django/db/backends/base/base.py#L231))

I have removed the check and also updated the tests to show the intended behaviour of the `TENANT_LIMIT_SET_CALLS` setting. 

I realise this will probably recreate the issue described in #114 and I tried to figure out the underlying issue but without more information it is hard to diagnose.