### PR TITLE
"--domain-" prefix in create_tenant command

### DIFF
--- a/django_tenants/management/commands/create_tenant.py
+++ b/django_tenants/management/commands/create_tenant.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                                              help='Specifies the %s for tenant.' % field.name)
 
         for field in self.domain_fields:
-            parser.add_argument('--%s' % field.name, help="Specifies the %s for the tenant's domain." % field.name)
+            parser.add_argument('--domain-%s' % field.name, help="Specifies the %s for the tenant's domain." % field.name)
 
         parser.add_argument('-s', action="store_true",
                                          help='Create a superuser afterwards.')


### PR DESCRIPTION
fix #167 by avoiding argument conflicts for those automatically added parameters from tenant and domain fields