### PR TITLE
Remove obsolete `TENANT_CREATION_FAKES_MIGRATIONS` setting

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -158,12 +158,6 @@ Optional Settings
     :Default: ``'public'``
     
     The schema name that will be treated as ``public``, that is, where the ``SHARED_APPS`` will be created.
-    
-.. attribute:: TENANT_CREATION_FAKES_MIGRATIONS
-
-    :Default: ``'True'``
-    
-    Sets if the models will be synced directly to the last version and all migration subsequently faked. Useful in the cases where migrations can not be faked and need to be ran individually. Be aware that setting this to `False` may significantly slow down the process of creating tenants.
 
 
 Tenant View-Routing


### PR DESCRIPTION
Listed in install guide, but relevant code no longer exists and in any case was limited to apps using South for migrations (see [issue 458 in django-tenant-schemas](https://github.com/bernardopires/django-tenant-schemas/issues/458)). 