### PR TITLE
Update Verbiage in Docs

### DIFF
--- a/docs/static.rst
+++ b/docs/static.rst
@@ -12,7 +12,7 @@ The classical Django ``FileSystemStorage`` and ``StaticFilesStorage`` cannot mak
 Static files finders aware tenant
 ---------------------------------
 
-The classical Django ``FileSystemFinder`` cannot finder path for files vary based on the current tenant so it's needed to use a special one which find ours files based on the tenant.
+The classical Django ``FileSystemFinder`` cannot determine paths for files based on the current tenant and therefore a special finder is needed, which can do so.
 
 To do this, first we need to structure our project so that each tenant stay separated into directories and thus we have a starting point to manipulate `templates files <templates.html>`_ and ``static files`` to each tenant:
 

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -12,7 +12,7 @@ The classical Django ``FileSystemStorage`` and ``StaticFilesStorage`` cannot mak
 Static files finders aware tenant
 ---------------------------------
 
-The classical Django ``FileSystemFinder`` cannot determine paths for files based on the current tenant and therefore a special finder is needed, which can do so.
+The classical Django ``FileSystemFinder`` cannot determine paths for files based on the current tenant and therefore a special finder which can do so is needed.
 
 To do this, first we need to structure our project so that each tenant stay separated into directories and thus we have a starting point to manipulate `templates files <templates.html>`_ and ``static files`` to each tenant:
 


### PR DESCRIPTION
The phrase "... cannot finder path for files vary based ..."([here](https://django-tenants.readthedocs.io/en/latest/static.html#multitenant-aware-static-and-media-files)) is a bit hard to read. Rephrasing for readability.