### PR TITLE
Add a test for the ModelManager delete method

### DIFF
--- a/django_tenants/signals.py
+++ b/django_tenants/signals.py
@@ -1,4 +1,7 @@
 from django.dispatch import Signal
+from django.db.models.signals import post_delete
+from django.dispatch import Signal, receiver
+from django_tenants.utils import get_tenant_model, schema_exists
 
 post_schema_sync = Signal(providing_args=['tenant'])
 post_schema_sync.__doc__ = """
@@ -9,3 +12,11 @@ schema_needs_to_be_sync = Signal(providing_args=['tenant'])
 schema_needs_to_be_sync.__doc__ = """
 Schema needs to be synced
 """
+
+@receiver(post_delete)
+def tenant_delete_callback(sender, instance, **kwargs):
+    if not isinstance(instance, get_tenant_model()):
+        return
+
+    if instance.auto_drop_schema and schema_exists(instance.schema_name):
+        instance._drop_schema(True)

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -479,3 +479,21 @@ class TenantTestCaseTest(BaseTestCase, TenantTestCase):
     def test_tenant_survives_after_method2(self):
         # The same tenant still exists even after the previous method call
         self.assertEqual(1, get_tenant_model().objects.all().count())
+
+
+class TenantManagerMethodsTestCaseTest(BaseTestCase):
+    """
+    Tests manager's delete method.
+    """
+    def test_manager_method_deletes_schema(self):
+        Client = get_tenant_model()
+        Client.auto_drop_schema = True
+        tenant = Client(schema_name='test')
+        tenant.save()
+        self.assertTrue(schema_exists(tenant.schema_name))
+
+        domain = get_tenant_domain_model()(tenant=tenant, domain='something.test.com')
+        domain.save()
+
+        Client.objects.filter(pk=tenant.pk).delete()
+        self.assertFalse(schema_exists(tenant.schema_name))        


### PR DESCRIPTION
Ensure the schema is deleted if we call the ModelManager's `delete` method instead of `Model.delete()`.