### PR TITLE
Fix template loader not switching between tenants

### DIFF
--- a/django_tenants/staticfiles/finders.py
+++ b/django_tenants/staticfiles/finders.py
@@ -31,7 +31,7 @@ class TenantFileSystemFinder(FileSystemFinder):
     def locations(self):
         """
         Lazy retrieval of list of locations with static files based on current tenant schema.
-        :return: The list of static file dirs that has been configured for this tenant.
+        :return: The list of static file dirs that have been configured for this tenant.
         """
         if self._locations.get(connection.schema_name, None) is None:
             schema_locations = []

--- a/django_tenants/template/loaders/filesystem.py
+++ b/django_tenants/template/loaders/filesystem.py
@@ -5,23 +5,45 @@ Wrapper for loading templates from the filesystem in a multi-tenant setting.
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db import connection
 from django.template.loaders.filesystem import Loader as BaseLoader
 
 from django_tenants import utils
 
 
 class Loader(BaseLoader):
-
     def __init__(self, engine, dirs=None):
+        self._dirs = {}
+
         super().__init__(engine)
 
-        if dirs is None:
+        if dirs is not None:
+            self.dirs = dirs
+
+    @property
+    def dirs(self):
+        """
+        Lazy retrieval of list of template directories based on current tenant schema.
+        :return: The list of template file dirs that have been configured for this tenant.
+        """
+        if self._dirs.get(connection.schema_name, None) is None:
             try:
                 # Use directories configured via MULTITENANT_TEMPLATE_DIRS
-                dirs = [utils.parse_tenant_config_path(dir_) for dir_ in settings.MULTITENANT_TEMPLATE_DIRS]
+                dirs = [
+                    utils.parse_tenant_config_path(dir_)
+                    for dir_ in settings.MULTITENANT_TEMPLATE_DIRS
+                ]
             except AttributeError:
                 raise ImproperlyConfigured(
-                    "To use %s.%s you must define the MULTITENANT_TEMPLATE_DIRS"
-                    % (__name__, Loader.__name__)
+                    "To use {}.{} you must define the MULTITENANT_TEMPLATE_DIRS setting.".format(
+                        __name__, Loader.__name__
+                    )
                 )
-        self.dirs = dirs
+
+            self.dirs = dirs
+
+        return self._dirs[connection.schema_name]
+
+    @dirs.setter
+    def dirs(self, value):
+        self._dirs[connection.schema_name] = value

--- a/django_tenants/tests/tenants/another_test/templates/index.html
+++ b/django_tenants/tests/tenants/another_test/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--Html file used to test template loaders and template caching-->
+<head>
+    <meta charset="UTF-8">
+    <title>This is another test</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -116,4 +116,3 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
-


### PR DESCRIPTION
Resolves a bug introduced as part of #198: templates of the first tenant that is loaded was being used for all subsequent tenants.