### PR TITLE
Fix DeprecationWarning for TenantMiddleware

### DIFF
--- a/django_tenants/middleware/__init__.py
+++ b/django_tenants/middleware/__init__.py
@@ -4,5 +4,8 @@ from django_tenants.middleware.main import TenantMainMiddleware
 
 
 class TenantMiddleware(TenantMainMiddleware):
-    warnings.warn("This class has been renamed to TenantMainMiddleware",
-                  DeprecationWarning)
+    def __init__(self, get_response=None):
+        super(TenantMainMiddleware, self).__init__(get_response=get_response)
+
+        warnings.warn("This class has been renamed to TenantMainMiddleware",
+                      DeprecationWarning)

--- a/django_tenants/tests/test_routes.py
+++ b/django_tenants/tests/test_routes.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.test.client import RequestFactory
 
-from django_tenants.middleware import TenantMiddleware
+from django_tenants.middleware import TenantMainMiddleware
 from django_tenants.tests.testcases import BaseTestCase
 from django_tenants.utils import get_tenant_model, get_tenant_domain_model, get_public_schema_name
 
@@ -37,7 +37,7 @@ class RoutesTestCase(BaseTestCase):
     def setUp(self):
         super(RoutesTestCase, self).setUp()
         self.factory = RequestFactory()
-        self.tm = TenantMiddleware()
+        self.tm = TenantMainMiddleware()
 
         self.tenant_domain = 'tenant.test.com'
         self.tenant = get_tenant_model()(schema_name='test')


### PR DESCRIPTION
The way the ``DeprecationWarning`` for ``TenantMiddleware`` is currently handled, the warning will be raised as soon as the Python interpreter loads ``django_tenants.middleware.__init__.py``.

We probably want to change this so that the deprecation warning is only raised if somebody actually tries to instantiate the middleware handler using the old class name?