### PR TITLE
Add DeprecationWarning for breaking change

### DIFF
--- a/django_tenants/files/storages.py
+++ b/django_tenants/files/storages.py
@@ -1,0 +1,17 @@
+import warnings
+
+from django_tenants.files.storage import TenantFileSystemStorage as NewTenantFileSystemStorage
+
+
+class TenantFileSystemStorage(NewTenantFileSystemStorage):
+    """
+    Deprecated - Use django_tenants.files.storage.TenantFileSystemStorage instead
+    """
+
+    def __init__(self, location=None, base_url=None, *args, **kwargs):
+        super(TenantFileSystemStorage, self).__init__(location=location, base_url=base_url, *args, **kwargs)
+
+        warnings.warn(
+            "TenantFileSystemStorage has been moved from django_tenants.files.storages to django_tenants.files.storage.",
+            DeprecationWarning
+        )

--- a/django_tenants/tests/test_static_files.py
+++ b/django_tenants/tests/test_static_files.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -7,6 +8,7 @@ from django.template import Engine
 
 from django_tenants import utils
 from django_tenants.files.storage import TenantFileSystemStorage
+from django_tenants.files.storages import TenantFileSystemStorage as OldTenantFileSystemStorage
 from django_tenants.staticfiles.finders import TenantFileSystemFinder
 from django_tenants.staticfiles.storage import TenantStaticFilesStorage
 from django_tenants.template.loaders.filesystem import Loader
@@ -145,6 +147,14 @@ class TenantFileSystemStorageTestCase(TenantTestCase):
             storage.url("foo.txt"),
             "/media/{}/other_dir/foo.txt".format(self.tenant.schema_name),
         )
+
+    def test_deprecated_module_raises_warning(self):
+        with warnings.catch_warnings(record=True) as warns:
+            deprecation_warning = "TenantFileSystemStorage has been moved from django_tenants.files.storages " \
+                                  "to django_tenants.files.storage."
+
+            OldTenantFileSystemStorage()
+            self.assertTrue(any(deprecation_warning in str(w.message) for w in warns))
 
 
 class TenantStaticFilesStorageTestCase(TenantTestCase):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -21,5 +21,5 @@ pushd dts_test_project
 EXECUTORS=( standard multiprocessing )
 
 for executor in "${EXECUTORS[@]}"; do
-    EXECUTOR=$executor python3 manage.py test django_tenants.tests
+    EXECUTOR=$executor python3 -Wd manage.py test django_tenants.tests
 done


### PR DESCRIPTION
This PR addresses the concern raised in [this comment](https://github.com/tomturner/django-tenants/pull/198#issuecomment-447999523), regarding the breaking change to the ``django_tenants.files.storages`` module.

Will now raise a DeprecationWarning when users try to use the old module.

Also changes the test runner parameters to show DeprecationWarnings.