### PR TITLE
Updated test.rst to reflect actual syntax

### DIFF
--- a/docs/test.rst
+++ b/docs/test.rst
@@ -47,13 +47,15 @@ If you have there are two routines to look at ``setup_tenant`` and ``setup_domai
     from django_tenants.test.client import TenantClient
 
     class BaseSetup(TenantTestCase):
-
-        def setup_tenant(self, tenant):
+        
+        @classmethod
+        def setup_tenant(cls, tenant):
             """
             Add any additional setting to the tenant before it get saved. This is required if you have
             required fields.
             """
-            tenant.company_name = "Test Company"
+            tenant.required_value = "Value"
+            return tenant
 
         def setup_domain(self, tenant):
             """


### PR DESCRIPTION
As per @BillBrower 's comment on [Issue 73](https://github.com/tomturner/django-tenants/issues/73), I've changed the syntax for `setup_tenant` method in `TenantTestCase`. This also works for `FastTenantTestCase`.