### PR TITLE
Fix changelog formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,9 +2,10 @@
 
 This changelog is used to track all major changes to django-tenants.
 
-## v2.1.0 (UNRELEASED)
+## v2.1.0 (31 Dec 2018)
 
 **Enhancements**
+
 - Added `TENANT_CREATION_FAKES_MIGRATIONS` configuration parameter that can be used to copy schemas from an existing "template" schema instead of running migrations.
 - `schema_context` now operates as a decorator too. Fixes: [#199](https://github.com/tomturner/django-tenants/issues/199).
 - Update template loaders and static file storage for Django > 2.0. Fixes: [#197](https://github.com/tomturner/django-tenants/issues/197).
@@ -16,6 +17,7 @@ This changelog is used to track all major changes to django-tenants.
 - Update tests for Django 2 and Python 3.
 
 **Fixes**
+
 - Fix setup.py to reference new `psycopg2-binary` dependency. Fixes [#174](https://github.com/tomturner/django-tenants/issues/174).
 - Add support for creating tenants that share field names with domains. Fixes: [#167](https://github.com/tomturner/django-tenants/issues/167).
 - Use `get_tenant` instead of `get_domain` in `DefaultTenantMiddleware` to lookup tenant. Fixes: [#154](https://github.com/tomturner/django-tenants/issues/154).


### PR DESCRIPTION
Looks like I messed up the rst formatting for the changelog on the first attempt.

Also adds release date for v2.1.0.