### PR TITLE
django admin: custom index template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ This changelog is used to track all major changes to django-tenants.
 **Enhancements**
 
 - TenantAdminMixin is available in order to register the tenant model. [#223]
+- Admin site: highlight with a different color the tenant apps. [#227]
+- Admin site: disable the tenant apps when in the public schema. [#227]
 
 ## v2.1.0 (31 Dec 2018)
 

--- a/django_tenants/templates/admin/index.html
+++ b/django_tenants/templates/admin/index.html
@@ -1,0 +1,58 @@
+{% extends "admin/index.html" %}
+{% load i18n admin_static tenant %}
+
+{% block content %}
+    <div id="content-main">
+        {% if app_list %}
+            {% for app in app_list %}
+                {% is_public_schema app as is_public_schema %}
+                {% is_tenant_app app as is_tenant_app %}
+                <div class="app-{{ app.app_label }} module">
+                    <table id="change-history">
+                        {% if is_tenant_app and is_public_schema %}
+                            <div class="module">
+                                <caption {% if is_tenant_app %}style="background-color:#f7d904"{% endif %}>
+                                    <div class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</div>
+                                    <tr>
+                                        <td scope="row">{% trans "Not available for Global schema" %}</td>
+                                    </tr>
+                                </caption>
+                            </div>
+                        {% else %}
+                            <caption {% if is_tenant_app %}style="background-color:#f7d904"{% endif %} >
+                                <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+                            </caption>
+                            {% for model in app.models %}
+                                <tr class="model-{{ model.object_name|lower }}">
+                                    {% if model.admin_url %}
+                                        <th scope="row"><a href="{{ model.admin_url }}">{{ model.name }}</a></th>
+                                    {% else %}
+                                        <th scope="row">{{ model.name }}</th>
+                                    {% endif %}
+
+                                    {% if model.add_url %}
+                                        <td><a href="{{ model.add_url }}" class="addlink">{% trans 'Add' %}</a></td>
+                                    {% else %}
+                                        <td>&nbsp;</td>
+                                    {% endif %}
+
+                                    {% if model.admin_url %}
+                                        {% if model.view_only %}
+                                            <td><a href="{{ model.admin_url }}" class="viewlink">{% trans 'View' %}</a></td>
+                                        {% else %}
+                                            <td><a href="{{ model.admin_url }}" class="changelink">{% trans 'Change' %}</a></td>
+                                        {% endif %}
+                                    {% else %}
+                                        <td>&nbsp;</td>
+                                    {% endif %}
+                                </tr>
+                            {% endfor %}
+                        {% endif %}
+                    </table>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p>{% trans "You don't have permission to view or edit anything." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/django_tenants/templatetags/tenant.py
+++ b/django_tenants/templatetags/tenant.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.template import Library
 from django.template.defaulttags import URLNode
 from django.template.defaulttags import url as default_url
@@ -23,3 +24,13 @@ def url(parser, token):
 @register.simple_tag
 def public_schema():
     return get_public_schema_name()
+
+
+@register.simple_tag()
+def is_tenant_app(app):
+    return app['app_label'] in [tenant_app.split('.')[-1] for tenant_app in settings.TENANT_APPS]
+
+
+@register.simple_tag(takes_context=True)
+def is_public_schema(context, app):
+    return context.request.tenant.schema_name == get_public_schema_name()


### PR DESCRIPTION
This PR introduces a custom index template:
- highlighting with a different color the tenant apps
- disable the tenant apps when in the public schema (avoiding exceptions)