### PR TITLE
Custom auth backend compatibility for TenantClient

### DIFF
--- a/django_tenants/test/client.py
+++ b/django_tenants/test/client.py
@@ -76,3 +76,19 @@ class TenantClient(Client):
             extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
 
         return super().delete(path, data, **extra)
+    
+    def login(self, **credentials):
+        # Create a dummy HttpRequest object and add HTTP_HOST
+        from django.http import HttpRequest
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = self.tenant.get_primary_domain().domain
+        
+        # Authenticate using django contrib's authenticate which passes the request on 
+        # to custom backends
+        from django.contrib.auth import authenticate
+        user = authenticate(request, **credentials)
+        if user:
+            super(TenantClient, self)._login(user)
+            return True
+        else:
+            return False


### PR DESCRIPTION
**Rationale**: I'm creating a B2B multitenant app that logs in user using a custom auth backend which uses e-mail as one of the identifiers and authenticates users by parsing `request.META['HTTP_HOST']` to get the relevant schema. However, by doing this, I wasn't able to use `TenantClient`'s `login()` method since my custom auth backend needs a request object but django client's `login` method chain (`login -> authenticate(**credentials)->... ` [as shown here](https://github.com/django/django/blob/master/django/test/client.py#L594)) doesn't pass on a `request` object to my custom auth backend. 

Since I feel like B2B multitenant apps may often use custom auth backends like I did, I felt it necessary to propose this change.