### PR TITLE
Refactored clearing of content types cache

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.http import Http404
 from django.utils.deprecation import MiddlewareMixin
@@ -42,15 +41,6 @@ class TenantMainMiddleware(MiddlewareMixin):
         request.tenant = tenant
 
         connection.set_tenant(request.tenant)
-
-        # Content type can no longer be cached as public and tenant schemas
-        # have different models. If someone wants to change this, the cache
-        # needs to be separated between public and shared schemas. If this
-        # cache isn't cleared, this can cause permission problems. For example,
-        # on public, a particular model has id 14, but on the tenants it has
-        # the id 15. if 14 is cached instead of 15, the permissions for the
-        # wrong model will be fetched.
-        ContentType.objects.clear_cache()
 
         # Do we have a public-specific urlconf?
         if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -3,9 +3,10 @@ import warnings
 from django.conf import settings
 from importlib import import_module
 
-from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django_tenants.utils import get_public_schema_name, get_limit_set_calls
 from django_tenants.postgresql_backend.introspection import DatabaseSchemaIntrospection
+from django_tenants.utils import get_public_schema_name, get_limit_set_calls
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 import django.db.utils
 import psycopg2
 
@@ -84,6 +85,14 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         self.include_public_schema = include_public
         self.set_settings_schema(schema_name)
         self.search_path_set = False
+        # Content type can no longer be cached as public and tenant schemas
+        # have different models. If someone wants to change this, the cache
+        # needs to be separated between public and shared schemas. If this
+        # cache isn't cleared, this can cause permission problems. For example,
+        # on public, a particular model has id 14, but on the tenants it has
+        # the id 15. if 14 is cached instead of 15, the permissions for the
+        # wrong model will be fetched.
+        ContentType.objects.clear_cache()
 
     def set_schema_to_public(self):
         """


### PR DESCRIPTION
Cherry-picked from `django-tenant-schemas`.
Fixes #232 