### PR TITLE
Moves documentation link (Quality of Life)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@ This application enables `django`_ powered websites to have multiple
 tenants via `PostgreSQL schemas`_. A vital feature for every
 Software-as-a-Service (SaaS) website.
 
+    Read the full documentaion here: `django-tenants.readthedocs.org`_
+
 Django provides currently no simple way to support multiple tenants
 using the same project instance, even when only the data is different.
 Because we don’t want you running many copies of your project, you’ll be


### PR DESCRIPTION
Quickly Googling for this library, and then wanting to navigate to the docs is slightly annoying as the link to the docs is hidden halfway through the main readme file (after links to other doc sites, like the postgreSQL docs).

This PR adds an earlier reference to the doc site.