### PR TITLE
Switch to psycopg2 dependency rather than psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     install_requires=[
         'Django >= 2.0,<2.2',
-        'psycopg2-binary',
+        'psycopg2',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
I know this has been discussed either way and I understand the desire to use `psycopg2-binary` during development but this approach is definitely not the answer.

Per the documentation here:
http://initd.org/psycopg/docs/install.html#binary-install-from-pypi

> If you are the maintainer of a publish package depending on psycopg2 you shouldn’t use psycopg2-binary as a module dependency.

Resolves #233 