### PR TITLE
Update documentation around manage.py migrate

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -143,9 +143,9 @@ Now run ``migrate_schemas --shared``, this will create the shared apps on the ``
 
     python manage.py migrate_schemas --shared
     
-.. warning::
+.. note::
 
-   Never use ``migrate`` or ``syncdb`` as it would sync *all* your apps to ``public``!
+   If you use ``migrate`` migrations will be applied to both shared and tenant schemas!
     
 .. warning::
 


### PR DESCRIPTION
- `manage.py syncdb` gives CommandError b/c syncdb was removed in
  Django 1.9
- `manage.py migrate` will apply all migrations to all available
  schemas, see SyncCommon.handle()::L153-156