### PR TITLE
Fix #302

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -137,7 +137,7 @@ class TenantMixin(models.Model):
         if has_schema and schema_exists(self.schema_name) and (self.auto_drop_schema or force_drop):
             self.pre_drop()
             cursor = connection.cursor()
-            cursor.execute('DROP SCHEMA %s CASCADE' % self.schema_name)
+            cursor.execute('DROP SCHEMA "%s" CASCADE' % self.schema_name)
 
     def pre_drop(self):
         """
@@ -186,7 +186,7 @@ class TenantMixin(models.Model):
                              verbosity=verbosity)
             else:
                 # create the schema
-                cursor.execute('CREATE SCHEMA %s' % self.schema_name)
+                cursor.execute('CREATE SCHEMA "%s"' % self.schema_name)
                 call_command('migrate_schemas',
                              tenant=True,
                              schema_name=self.schema_name,

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -21,7 +21,7 @@ original_backend = import_module(ORIGINAL_BACKEND + '.base')
 EXTRA_SEARCH_PATHS = getattr(settings, 'PG_EXTRA_SEARCH_PATHS', [])
 
 # from the postgresql doc
-SQL_IDENTIFIER_RE = re.compile(r'^[_a-zA-Z][_a-zA-Z0-9]{,62}$')
+SQL_IDENTIFIER_RE = re.compile(r'^[_a-zA-Z0-9]{1,63}$')
 SQL_SCHEMA_NAME_RESERVED_RE = re.compile(r'^pg_', re.IGNORECASE)
 
 

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -161,6 +161,7 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
             # if the next instruction is not a rollback it will just fail also, so
             # we do not have to worry that it's not the good one
             try:
+                search_paths = ['\'{}\''.format(s) for s in search_paths]
                 cursor_for_search_path.execute('SET search_path = {0}'.format(','.join(search_paths)))
             except (django.db.utils.DatabaseError, psycopg2.InternalError):
                 self.search_path_set = False

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -275,6 +275,22 @@ class TenantDataAndSettingsTest(BaseTestCase):
 
         self.created = [domain, tenant]
 
+    def test_tenant_schema_creation_with_sql_keyword_name(self):
+        tenant = get_tenant_model()(schema_name='select')
+        tenant.save()
+
+        self.assertTrue(schema_exists(tenant.schema_name))
+
+        self.created = [tenant]
+
+    def test_tenant_schema_creation_with_only_numbers_name(self):
+        tenant = get_tenant_model()(schema_name='123')
+        tenant.save()
+
+        self.assertTrue(schema_exists(tenant.schema_name))
+
+        self.created = [tenant]
+
 
 class BaseSyncTest(BaseTestCase):
     """


### PR DESCRIPTION
Fix a crash (ProgrammingError) when attempting to create a schema named like a SQL keyword (select, where, ...)
Allow to create a tenant named with only numbers (123).