### PR TITLE
Update dependency psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     install_requires=[
         'Django >= 2.1,<3.0',
-        'psycopg2',
+        'psycopg2-binary',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Changing dependency to `psycopg2-binary`. With it is not necessary to install Postgresql on the host