### PR TITLE
Added database support to validate schemas

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -49,7 +49,7 @@ class MigrateSchemasCommand(SyncCommon):
             executor.run_migrations(tenants=[self.PUBLIC_SCHEMA_NAME])
         if self.sync_tenant:
             if self.schema_name and self.schema_name != self.PUBLIC_SCHEMA_NAME:
-                if not schema_exists(self.schema_name):
+                if not schema_exists(self.schema_name, self.options.get('database', None)):
                     raise RuntimeError('Schema "{}" does not exist'.format(
                         self.schema_name))
                 else:

--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -24,7 +24,7 @@ def run_migrations(args, options, executor_codename, schema_name, allow_atomic=T
             msg
         )
 
-    connection = connections[get_tenant_database_alias()]
+    connection = connections[options.get('database', get_tenant_database_alias())]
     connection.set_schema(schema_name)
 
     stdout = OutputWrapper(sys.stdout)

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -136,8 +136,8 @@ def django_is_in_test_mode():
     return hasattr(mail, 'outbox')
 
 
-def schema_exists(schema_name):
-    _connection = connections[get_tenant_database_alias()]
+def schema_exists(schema_name, database=get_tenant_database_alias()):
+    _connection = connections[database]
     cursor = _connection.cursor()
 
     # check if this schema already exists in the db


### PR DESCRIPTION
When using the method `validate_schemas` the database used is the default one. This pull request adds an argument so it can validate schemas on different databases.