### PR TITLE
Addresses #303

### DIFF
--- a/django_tenants/files/storage.py
+++ b/django_tenants/files/storage.py
@@ -53,7 +53,8 @@ class TenantFileSystemStorage(FileSystemStorage):
 
     @property
     def base_url(self):
-        relative_tenant_media_url = utils.parse_tenant_config_path(self.relative_media_url)
+        baseurl = super().base_url
+        relative_tenant_media_url = os.path.join(baseurl, utils.parse_tenant_config_path('%s')) + "/"
 
         if self._base_url is None:
             return relative_tenant_media_url


### PR DESCRIPTION
Sorry, i botches the previous PR.

This change doesn't use the relative media root for the base urls.  If you use the media root, you might be using filesystem paths which don't relaly belong in the urls.  For example:

```
MULTITENANT_RELATIVE_MEDIA_ROOT = '/mnt/foo'
MEDIA_URL = '/foo/static/'
```
This would yield a url `/foo/static/mnt/foo/my_tenant/image.jpg` which probably isn't what you want. The `MULTITENANT_RELATIVE_MEDIA_ROOT` should have no bearing on the url, unless i misread the code
