### PR TITLE
Removed psycopg2 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     ],
     install_requires=[
         'Django >= 2.1,<3.1',
-        'psycopg2',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
As discussed in #317, #233, #311: let the user decide which version of psycopg2 it uses. 