### PR TITLE
add --noinput argument support to create_tenant command

### DIFF
--- a/django_tenants/management/commands/create_tenant.py
+++ b/django_tenants/management/commands/create_tenant.py
@@ -1,6 +1,6 @@
 from django.core import exceptions
 from django.core.management import call_command
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db.utils import IntegrityError
 from django.utils.encoding import force_str
 from django_tenants.utils import get_tenant_model, get_tenant_domain_model
@@ -29,6 +29,15 @@ class Command(BaseCommand):
             parser.add_argument('--domain-%s' % field.attname,
                                 help="Specifies the %s for the tenant's domain." % field.attname)
 
+        parser.add_argument(
+            '--noinput', '--no-input', action='store_false', dest='interactive',
+            help=(
+                'Tells Django to NOT prompt the user for input of any kind. '
+                'You must use --schema_names with --noinput, along with an option for '
+                'any other required field.'
+            ),
+        )
+
         parser.add_argument('-s', action="store_true",
                             help='Create a superuser afterwards.')
 
@@ -37,43 +46,56 @@ class Command(BaseCommand):
         tenant_data = {}
         for field in self.tenant_fields:
             input_value = options.get(field.attname, None)
-            tenant_data[field.attname] = input_value
+            if input_value is not None:
+                tenant_data[field.attname] = field.clean(input_value, None)
 
         domain_data = {}
         for field in self.domain_fields:
             input_value = options.get('domain_%s' % field.attname, None)
-            domain_data[field.attname] = input_value
+            if input_value is not None:
+                domain_data[field.attname] = field.clean(input_value, None)
 
-        while True:
-            for field in self.tenant_fields:
-                if tenant_data.get(field.attname, '') == '':
-                    input_msg = field.verbose_name
-                    default = field.get_default()
-                    if default:
-                        input_msg = "%s (leave blank to use '%s')" % (input_msg, default)
+        if options['interactive']:
+            while True:
+                for field in self.tenant_fields:
+                    if tenant_data.get(field.attname, '') == '':
+                        input_msg = field.verbose_name
+                        default = field.get_default()
+                        if default:
+                            input_msg = "%s (leave blank to use '%s')" % (input_msg, default)
 
-                    input_value = input(force_str('%s: ' % input_msg)) or default
-                    tenant_data[field.attname] = input_value
+                        input_value = input(force_str('%s: ' % input_msg)) or default
+                        tenant_data[field.attname] = input_value
+                tenant = self.store_tenant(**tenant_data)
+                if tenant is not None:
+                    break
+                tenant_data = {}
+        else:
             tenant = self.store_tenant(**tenant_data)
-            if tenant is not None:
-                break
-            tenant_data = {}
+            if tenant is None:
+                raise CommandError("Missing required fields")
 
-        while True:
-            domain_data['tenant_id'] = tenant.pk
-            for field in self.domain_fields:
-                if domain_data.get(field.attname, '') == '':
-                    input_msg = field.verbose_name
-                    default = field.get_default()
-                    if default:
-                        input_msg = "%s (leave blank to use '%s')" % (input_msg, default)
+        if options['interactive']:
+            while True:
+                domain_data['tenant_id'] = tenant.pk
+                for field in self.domain_fields:
+                    if domain_data.get(field.attname, '') == '':
+                        input_msg = field.verbose_name
+                        default = field.get_default()
+                        if default:
+                            input_msg = "%s (leave blank to use '%s')" % (input_msg, default)
 
-                    input_value = input(force_str('%s: ' % input_msg)) or default
-                    domain_data[field.attname] = input_value
-            domain = self.store_tenant_domain(**domain_data)
-            if domain is not None:
-                break
-            domain_data = {}
+                        input_value = input(force_str('%s: ' % input_msg)) or default
+                        domain_data[field.attname] = input_value
+                domain = self.store_tenant_domain(**domain_data)
+                if domain is not None:
+                    break
+                domain_data = {}
+        else:
+                domain_data['tenant_id'] = tenant.pk
+                domain = self.store_tenant_domain(**domain_data)
+                if domain is None:
+                    raise CommandError("Missing required domain fields")
 
         if options.get('s', None):
             self.stdout.write("Create superuser for %s" % tenant_data['schema_name'])


### PR DESCRIPTION
This patch adds support for `--noinput` (or `--no-input`) argument to `create_tenant` command.
If used, it will not ask for user input even for missing fields. And in case one of these missing fields is required, the command will exit with a "Missing required field" error.

This patch will allow using the command on scripts where there is no access to terminal input or when script automation is needed.