### PR TITLE
Swap pg_authid for pg_roles

### DIFF
--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -130,7 +130,7 @@ BEGIN
   FOR arec IN
     SELECT n.nspname as schemaname, a.rolname as ownername , c.collname, c.collprovider,  c.collcollate as locale,
     'CREATE COLLATION ' || quote_ident(dest_schema) || '."' || c.collname || '" (provider = ' || CASE WHEN c.collprovider = 'i' THEN 'icu' WHEN c.collprovider = 'c' THEN 'libc' ELSE '' END || ', locale = ''' || c.collcollate || ''');' as COLL_DDL
-    FROM pg_collation c JOIN pg_namespace n ON (c.collnamespace = n.oid) JOIN pg_authid a ON (c.collowner = a.oid) WHERE n.nspname = quote_ident(source_schema) order by c.collname
+    FROM pg_collation c JOIN pg_namespace n ON (c.collnamespace = n.oid) JOIN pg_roles a ON (c.collowner = a.oid) WHERE n.nspname = quote_ident(source_schema) order by c.collname
   LOOP
     BEGIN
       cnt := cnt + 1;


### PR DESCRIPTION
Doing this again as I accidentally deleted my repo for #380
- As far as I know, these tables are equivalent apart from the password column, however managed database services (Digital Ocean, and RDS) don't allow access to pg_authid