### PR TITLE
Add Postgres test matrix in CI. Closes #383

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,45 @@
+name: postgres
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  test_matrix:
+    name: ${{ matrix.postgres-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [3.6]
+        postgres-version: [latest, 12, 11, 10, 9, 9.5]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python dependencies
+      run: |
+        pip install psycopg2
+        # always use latest Django here b/c the point is to test PostgreSQL compatibility
+        pip install Django
+        python setup.py develop
+
+    - name: Create database
+      run: |
+        # maps the container port to localhost
+        docker run --name db -p 5432:5432 -d -e POSTGRES_PASSWORD=testing postgres:${{ matrix.postgres-version }}
+
+        sleep 10 # wait for server to initialize
+        PGPASSWORD="testing" psql -c 'create database dts_test_project;' -U postgres -h localhost
+
+    - name: Run tests
+      run: |
+        export DATABASE_PASSWORD="testing"
+        ./run_tests.sh
+


### PR DESCRIPTION
- uses official Postgres docker images, see
  https://hub.docker.com/_/postgres
- uses GitHub actions which seems rather fast!
- uses a single version of Python b/c the point here is
  not to test the Python matrix
- uses latest Django b/c we're not testing Django compatibility here

- latest==12 ATM but this will change in future and the matrix will
pick up the next version automatically

- 9==9.6, hence 9.5 is specified explicitly as major.minor


ATM fails for `test_clone_schema()` which isn't related to the current changes.